### PR TITLE
EXPERIMENTAL: Allow Duplicate Roles

### DIFF
--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -376,6 +376,7 @@ namespace TownOfUs
             (DisableSkipButtonMeetings)Generate.SkipButtonDisable.Get();
         public static GameMode GameMode =>
             (GameMode)Generate.GameMode.Get();
+        public static bool DuplicateRoles => (bool)Generate.DuplicateRoles.Get();
         public static int MayorCultistOn => (int)Generate.MayorCultistOn.Get();
         public static int SeerCultistOn => (int)Generate.SeerCultistOn.Get();
         public static int SheriffCultistOn => (int)Generate.SheriffCultistOn.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -142,6 +142,7 @@ namespace TownOfUs.CustomOption
 
         public static CustomHeaderOption GameModeSettings;
         public static CustomStringOption GameMode;
+        public static CustomToggleOption DuplicateRoles;
 
         public static CustomHeaderOption ClassicSettings;
         public static CustomNumberOption MinNeutralBenignRoles;
@@ -730,6 +731,7 @@ namespace TownOfUs.CustomOption
             GameModeSettings =
                 new CustomHeaderOption(num++, MultiMenu.main, "Game Mode Settings");
             GameMode = new CustomStringOption(num++, MultiMenu.main, "Game Mode", new[] {"Classic", "All Any", "Killing Only", "Cultist" });
+            DuplicateRoles = new CustomToggleOption(num++, MultiMenu.main, "[EXPERIMENTAL] Allow Duplicate Roles", false);
 
             ClassicSettings =
                 new CustomHeaderOption(num++, MultiMenu.main, "Classic Game Mode Settings");

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -285,13 +285,32 @@ namespace TownOfUs
             impRoles.Shuffle();
 
             // Hand out appropriate roles to crewmates and impostors.
-            foreach (var (type, _, unique) in crewRoles)
+
+            if (!CustomGameOptions.DuplicateRoles)
             {
-                Role.GenRole<Role>(type, crewmates);
+                foreach (var (type, _, unique) in crewRoles)
+                {
+                    Role.GenRole<Role>(type, crewmates);
+                }
+                foreach (var (type, _, unique) in impRoles)
+                {
+                    Role.GenRole<Role>(type, impostors);
+                }
             }
-            foreach (var (type, _, unique) in impRoles)
+            else
             {
-                Role.GenRole<Role>(type, impostors);
+                foreach (var crewmate in crewmates)
+                {
+                    int roleId = Random.Range(0, crewRoles.Count);
+                    (Type type, int _, bool unique) role = crewRoles[roleId];
+                    Role.GenRole<Role>(role.type, crewmate);
+                }
+                foreach (var impostor in impostors)
+                {
+                    int roleId = Random.Range(0, impRoles.Count);
+                    (Type type, int _, bool unique) role = impRoles[roleId];
+                    Role.GenRole<Role>(role.type, impostor);
+                }
             }
 
             // Assign vanilla roles to anyone who did not receive a role.


### PR DESCRIPTION
Experimental option to allow grant of the same role to multiple players.
(Works only for Classic game mode)

### Known Issues:
- Lawyer has no target